### PR TITLE
Add Locale Detection

### DIFF
--- a/authy.go
+++ b/authy.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	jab "github.com/cloudfoundry-attic/jibber_jabber"
 )
 
 const (
@@ -183,9 +185,13 @@ func (c Client) QueryAuthenticatorApps(ctx context.Context, userID uint64, devic
 	form.Set("otp1", codes[0])
 	form.Set("otp2", codes[1])
 	form.Set("otp3", codes[2])
-	form.Set("locale", "en-GB")
+	language, err := jab.DetectIETF();
+	if err != nil {
+		language = "en-GB";
+	}
+	form.Set("locale", language)
 
 	var resp AuthenticatorAppsResponse
 	return resp, c.doRequest(ctx, http.MethodPost,
-		fmt.Sprintf("users/%d/devices/%d/apps/sync", userID, deviceID), strings.NewReader(form.Encode()), &resp)
+		fmt.Sprintf("users/%d/devices/%d/apps/sync?%s", userID, deviceID, form.Encode()), strings.NewReader(form.Encode()), &resp)
 }

--- a/cmd/authy-export/go.mod
+++ b/cmd/authy-export/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/alexzorin/authy v0.0.0-00010101000000-000000000000
+	github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 )
 

--- a/cmd/authy-export/go.sum
+++ b/cmd/authy-export/go.sum
@@ -1,3 +1,5 @@
+github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:Yg2hDs4b13Evkpj42FU2idX2cVXVFqQSheXYKM86Qsk=
+github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:MgJyK38wkzZbiZSKeIeFankxxSA8gayko/nr5x5bgBA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Added Locale Detection to QueryAuthenticatorApps-function.
Also appended the query parameters, even though the call seems to work perfectly without them.

@alexzorin Thanks for providing this feature in the first place, where you had little intention yesterday. Much appreciated!
When I checked, the query parameters where missing, so I guessed that would be nice. As I'm from Germany, my locale entry was different, so the current locale is now requested via jibber_jabber.

If you feel this contribution is unnecessary, feel free to close this PR.

// Kai