### PR TITLE
Add support for saving and reloading encrypted backup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Please be careful. You can get your Authy account suspended very easily by using
 ### authy-export
 This program will enrol itself as an additional device on your Authy account and export all of your TOTP tokens in [Key URI Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format).
 
+It is also able to save the TOTP database in a JSON file encrypted with your Authy backup password, which can be used for backup purposes, and to read it back in order to decrypt it.
+
 **Installation**
 
 Pre-built binaries are available from the [releases page](https://github.com/alexzorin/authy/releases). (Windows binaries have been removed because of continual false positive virus complaints, sorry).
@@ -34,6 +36,7 @@ go install github.com/alexzorin/authy/...@latest
 4. If the device registration is successful, the program will save its authentication credential (a random value) to `$HOME/authy-go.json` for further uses. **Make sure to delete this file and de-register the device after you're finished.**
 5. If the program is able to fetch your TOTP encrypted database, it will prompt you for your Authy backup password. This is required to decrypt the TOTP secrets for the next step. 
 6. The program will dump all of your TOTP tokens in URI format, which you can use to import to other applications.
+7. Alternatively, you can save the TOTP encrypted database to a file with the `--save` option, and reload it later with the `--load` option in order to decrypt it and dump the tokens.
 
 If you [notice any missing TOTP tokens](https://github.com/alexzorin/authy/issues/1#issuecomment-516187701), please try toggling "Authenticator Backups" in your Authy settings, to force your backup to be resynchronized.
 

--- a/objects.go
+++ b/objects.go
@@ -245,10 +245,3 @@ func (a AuthenticatorApp) Token() (string, error) {
 	encoder := base32.StdEncoding.WithPadding(base32.NoPadding)
 	return encoder.EncodeToString(decoded), nil
 }
-
-type AuthenticatorResponse struct {
-	Tokens AuthenticatorTokensResponse `json:"tokens"`
-
-	Apps AuthenticatorAppsResponse `json:"apps"`
-}
-

--- a/objects.go
+++ b/objects.go
@@ -245,3 +245,10 @@ func (a AuthenticatorApp) Token() (string, error) {
 	encoder := base32.StdEncoding.WithPadding(base32.NoPadding)
 	return encoder.EncodeToString(decoded), nil
 }
+
+type AuthenticatorResponse struct {
+	Tokens AuthenticatorTokensResponse `json:"tokens"`
+
+	Apps AuthenticatorAppsResponse `json:"apps"`
+}
+


### PR DESCRIPTION
Thanks for this great tool, I wanted to use this code to keep encrypted backup files of my tokens, so I made some modifications and then tried to make them clean so that it can be useful to others:

Added two command line arguments (with default values the behavior is unchanged):
- `-save` in order to save the encrypted backup file as json. In this case the decryption and console display of the tokens are disabled so that backup password is not required.
- `-load` in order to load an encrypted backup file instead of fetching it from the server

I'll add some documentation if you are ok with merging this. I would advise to "hide whitespace" in the "diff view" for the review, as most of the changes are indented lines that are now in `if` blocks.

It's my first time reading or writing Go, so don't hesitate to advise improvements!