### PR TITLE
Use auth key derivation from API response

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -24,7 +24,6 @@ import (
 const (
 	totpTimeStep = 10
 	totpDigits   = 7
-	kdfRounds    = 1e3
 	kdfKeyLen    = 256
 )
 
@@ -86,7 +85,7 @@ func generateTOTP(secret []byte, t time.Time, digits int, timeStep int64) (strin
 	return fmt.Sprintf(f, mod), nil
 }
 
-func decryptToken(encryptedSeedB64, salt, passphrase string) (string, error) {
+func decryptToken(kdfRounds int, encryptedSeedB64, salt, passphrase string) (string, error) {
 	encryptedSeed, err := base64.StdEncoding.DecodeString(encryptedSeedB64)
 	if err != nil {
 		return "", fmt.Errorf("Error decoding encrypted seed: %v", err)

--- a/objects.go
+++ b/objects.go
@@ -154,6 +154,7 @@ type AuthenticatorToken struct {
 	// The encrypted TOTP seed
 	EncryptedSeed string `json:"encrypted_seed"`
 
+	// The number of rounds for password-based key derivation
 	KDFRounds int `json:"key_derivation_iterations"`
 
 	// User-nominated name for the token

--- a/objects.go
+++ b/objects.go
@@ -154,6 +154,8 @@ type AuthenticatorToken struct {
 	// The encrypted TOTP seed
 	EncryptedSeed string `json:"encrypted_seed"`
 
+	KDFRounds int `json:"key_derivation_iterations"`
+
 	// User-nominated name for the token
 	Name string `json:"name"`
 
@@ -173,7 +175,7 @@ type AuthenticatorToken struct {
 // Decrypt returns the base32-encoded seed for this TOTP token, decrypted
 // by passphrase.
 func (t AuthenticatorToken) Decrypt(passphrase string) (string, error) {
-	secret, err := decryptToken(t.EncryptedSeed, t.Salt, passphrase)
+	secret, err := decryptToken(t.KDFRounds, t.EncryptedSeed, t.Salt, passphrase)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As mentioned in #30, the API response for `AuthenticatorToken` now includes `key_derivation_iterations`, so I've modified `decryptToken` to use that value instead of a constant.

Closes #30